### PR TITLE
fix: persist enabled plugins across restarts

### DIFF
--- a/Styx/Plugins/PluginManager.cs
+++ b/Styx/Plugins/PluginManager.cs
@@ -25,6 +25,9 @@ namespace Styx.Plugins
         /// </summary>
         public static bool IsBuildingPlugins { get; private set; }
 
+        /// <summary>Set during teardown so cleanup-disables don't rewrite the saved EnabledPlugins list.</summary>
+        public static bool IsTearingDown { get; set; }
+
         /// <summary>
         /// Gets all loaded plugins.
         /// </summary>
@@ -82,6 +85,10 @@ namespace Styx.Plugins
         /// </summary>
         public static void UpdateEnabledPlugins()
         {
+            // don't rewrite the saved list during build or teardown — both would persist an empty set
+            if (IsBuildingPlugins || IsTearingDown)
+                return;
+
             try
             {
                 var enabledPluginNames = Plugins

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -507,6 +507,8 @@ namespace CopilotBuddy.UI
             }
 
             // Disable all plugins so overlay/hotkeys and plugin-owned resources are released.
+            // IsTearingDown keeps these cleanup-disables from wiping the saved EnabledPlugins list.
+            Styx.Plugins.PluginManager.IsTearingDown = true;
             foreach (var pluginContainer in Styx.Plugins.PluginManager.Plugins)
             {
                 pluginContainer.Enabled = false;


### PR DESCRIPTION
## Problem
Enabled plugins were forgotten on every restart — `CharacterSettings.EnabledPlugins` always loaded empty.

## Cause
The saved list is recomputed from live `PluginContainer` state and got rewritten while that state was incomplete, in two places:
- **Load:** in `RefreshPlugins`, each enabled container's ctor calls `UpdateEnabledPlugins()` before it is added to `Plugins` → persisted an incomplete set.
- **Teardown:** `MainWindow` disables all plugins for cleanup before `SaveSettings()` runs → saved an empty list.

## Fix
Guard `UpdateEnabledPlugins()` so it only rewrites the saved list on a genuine user toggle — skipped during `IsBuildingPlugins` (existing flag) and a new `IsTearingDown` flag set around the teardown disable loop.

Navigation-agnostic (UI/Styx only) — applies to `1x1` as well.