### PR TITLE
fix: restore open-world safe-res (death loop on camped corpse)

### DIFF
--- a/Styx/WoWInternals/WoWObjects/LocalPlayer.cs
+++ b/Styx/WoWInternals/WoWObjects/LocalPlayer.cs
@@ -385,12 +385,15 @@ namespace Styx.WoWInternals.WoWObjects
         {
             get
             {
-                // HB 4.3.4 pattern: BotEvents sets InstanceDeathLocation from dungeon map DB
-                // when player dies inside an instance, and clears it to Empty otherwise.
-                // Fall back to CorpsePoint when InstanceDeathLocation is not set.
-                if (InstanceDeathLocation != WoWPoint.Empty)
+                // HB 4.3.4: BotEvents sets InstanceDeathLocation from the dungeon map DB on an
+                // instance death, else leaves it Empty. Return Empty (NOT CorpsePoint) in the open
+                // world — the death tree reads "!= Empty" as "died in an instance". The CorpsePoint
+                // fallback (regression 9572f78) made every open-world death take that branch, which
+                // walks the ghost onto the corpse itself (there is no portal) instead of
+                // FindSafeResPoint's safe spot → endless SafeRes-into-the-pack loop on a camp.
+                if (InstanceDeathLocation != WoWPoint.Empty && InstanceDeathLocation != WoWPoint.Zero)
                     return InstanceDeathLocation;
-                return CorpsePoint;
+                return WoWPoint.Empty;
             }
         }
         


### PR DESCRIPTION
## Problem
On an open-world death the bot ignored the safe-resurrect point and grabbed the corpse in place, resurrecting straight into whatever killed it. When the corpse is camped by a pack this loops: res → die → res → die.

## Cause
`LocalPlayer.InstanceCorpseLocation` fell back to `CorpsePoint` when `InstanceDeathLocation` was unset (regression in 9572f78) — and nothing ever populates `InstanceDeathLocation`, so it was non-`Empty` on every open-world death. `LevelBot`'s corpse-retrieval reads `InstanceCorpseLocation != WoWPoint.Empty` as "died in an instance", so it took that branch and walked the ghost onto the corpse instead of `FindSafeResPoint`'s safe spot.

## Fix
Return `WoWPoint.Empty` outside instances, as the port did before 9572f78. `FindSafeResPoint` then walks the ghost to a safe edge of the corpse-recovery radius and resurrects clear of the pack.

Navigation-agnostic (Styx only) — applies to `1x1` as well.
